### PR TITLE
[Chore] Change Fjord params to const

### DIFF
--- a/core/types/rollup_cost.go
+++ b/core/types/rollup_cost.go
@@ -129,22 +129,16 @@ func NewL1CostFunc(config *params.ChainConfig, statedb StateGetter) L1CostFunc {
 		l1BlobBaseFee := statedb.GetState(L1BlockAddr, L1BlobBaseFeeSlot).Big()
 		l1BaseFee := statedb.GetState(L1BlockAddr, L1BaseFeeSlot).Big()
 		if config.IsOptimismFjord(blockTime) {
-			// Edge case: the very first Fjord block requires we use the Ecotone cost
-			// function. We detect this scenario by checking this block time is within
-			// the range of the first Fjord block
-			if !config.IsOptimismFjordActivationBlock(blockTime) {
-				l1BaseFeeScalar, l1BlobBaseFeeScalar := extractEcotoneFeeParams(l1FeeScalars)
-				return newL1CostFuncFjord(
-					l1BaseFee,
-					l1BlobBaseFee,
-					l1BaseFeeScalar,
-					l1BlobBaseFeeScalar,
-					l1CostIntercept,
-					l1CostFastlzCoef,
-					l1CostTxSizeCoef,
-				)
-			}
-			log.Info("using Ecotone l1 cost func for first Fjord block", "time", blockTime)
+			l1BaseFeeScalar, l1BlobBaseFeeScalar := extractEcotoneFeeParams(l1FeeScalars)
+			return newL1CostFuncFjord(
+				l1BaseFee,
+				l1BlobBaseFee,
+				l1BaseFeeScalar,
+				l1BlobBaseFeeScalar,
+				l1CostIntercept,
+				l1CostFastlzCoef,
+				l1CostTxSizeCoef,
+			)
 		}
 		if config.IsOptimismEcotone(blockTime) {
 			// Edge case: the very first Ecotone block requires we use the Bedrock cost

--- a/core/types/rollup_cost.go
+++ b/core/types/rollup_cost.go
@@ -130,7 +130,8 @@ func NewL1CostFunc(config *params.ChainConfig, statedb StateGetter) L1CostFunc {
 		l1BaseFee := statedb.GetState(L1BlockAddr, L1BaseFeeSlot).Big()
 		if config.IsOptimismFjord(blockTime) {
 			// Edge case: the very first Fjord block requires we use the Ecotone cost
-			// function. We detect this scenario by ???
+			// function. We detect this scenario by checking this block time is within
+			// the range of the first Fjord block
 			if !config.IsOptimismFjordActivationBlock(blockTime) {
 				l1BaseFeeScalar, l1BlobBaseFeeScalar := extractEcotoneFeeParams(l1FeeScalars)
 				return newL1CostFuncFjord(
@@ -278,7 +279,7 @@ func newL1CostFuncFjord(l1BaseFee, l1BlobBaseFee, l1BaseFeeScalar, l1BlobBaseFee
 // extractL1GasParams extracts the gas parameters necessary to compute gas costs from L1 block info
 func extractL1GasParams(config *params.ChainConfig, time uint64, data []byte) (l1BaseFee *big.Int, costFunc l1CostFunc, feeScalar *big.Float, err error) {
 	// Both Ecotone and Fjord use the same function selector
-	if config.IsEcotone(time) || config.IsFjord(time) {
+	if config.IsEcotone(time) {
 		// edge case: for the very first Ecotone block we still need to use the Bedrock
 		// function. We detect this edge case by seeing if the function selector is the old one
 		if len(data) >= 4 && !bytes.Equal(data[0:4], BedrockL1AttributesSelector) {

--- a/params/config.go
+++ b/params/config.go
@@ -680,6 +680,7 @@ func (c *ChainConfig) IsOptimismFjordActivationBlock(time uint64) bool {
 	return c.IsOptimism() &&
 		c.IsFjord(time) &&
 		c.BlockTime != nil &&
+		(time-*c.BlockTime) > 0 &&
 		!c.IsFjord(time-*c.BlockTime)
 }
 

--- a/params/config.go
+++ b/params/config.go
@@ -378,9 +378,6 @@ type ChainConfig struct {
 
 	// Optimism config, nil if not active
 	Optimism *OptimismConfig `json:"optimism,omitempty"`
-
-	// Seconds per L2 block
-	BlockTime *uint64 `json:"blockTime,omitempty"`
 }
 
 // EthashConfig is the consensus engine configs for proof-of-work based sealing.
@@ -672,16 +669,6 @@ func (c *ChainConfig) IsOptimismEcotone(time uint64) bool {
 
 func (c *ChainConfig) IsOptimismFjord(time uint64) bool {
 	return c.IsOptimism() && c.IsFjord(time)
-}
-
-// IsOptimismFjordActivationBlock returns whether the specified block is the first block
-// subject to the Fjord upgrade. Fjord activation at genesis does not count.
-func (c *ChainConfig) IsOptimismFjordActivationBlock(time uint64) bool {
-	return c.IsOptimism() &&
-		c.IsFjord(time) &&
-		c.BlockTime != nil &&
-		(time-*c.BlockTime) > 0 &&
-		!c.IsFjord(time-*c.BlockTime)
 }
 
 // IsOptimismPreBedrock returns true iff this is an optimism node & bedrock is not yet active

--- a/params/config.go
+++ b/params/config.go
@@ -378,6 +378,9 @@ type ChainConfig struct {
 
 	// Optimism config, nil if not active
 	Optimism *OptimismConfig `json:"optimism,omitempty"`
+
+	// Seconds per L2 block
+	BlockTime *uint64 `json:"blockTime,omitempty"`
 }
 
 // EthashConfig is the consensus engine configs for proof-of-work based sealing.
@@ -669,6 +672,15 @@ func (c *ChainConfig) IsOptimismEcotone(time uint64) bool {
 
 func (c *ChainConfig) IsOptimismFjord(time uint64) bool {
 	return c.IsOptimism() && c.IsFjord(time)
+}
+
+// IsOptimismFjordActivationBlock returns whether the specified block is the first block
+// subject to the Fjord upgrade. Fjord activation at genesis does not count.
+func (c *ChainConfig) IsOptimismFjordActivationBlock(time uint64) bool {
+	return c.IsOptimism() &&
+		c.IsFjord(time) &&
+		c.BlockTime != nil &&
+		!c.IsFjord(time-*c.BlockTime)
 }
 
 // IsOptimismPreBedrock returns true iff this is an optimism node & bedrock is not yet active


### PR DESCRIPTION
Convert `CostTxSizeCoefSlotOffset`, `CostFastlzCoefSlotOffset`, `CostInterceptSlotOffset` to pre-defined value. See https://github.com/ethereum-optimism/specs/pull/25/files for more details.

Open question:
right now Fjord upgrade won't change the `L1BlobBaseFeeSlot`. Checking what's the best way to identify the first Fjord block which needs to use Ecotone cost function.